### PR TITLE
influ$data is same length as preds using bind_cols

### DIFF
--- a/influ.R
+++ b/influ.R
@@ -264,7 +264,7 @@ Influence$calc <- function(.){
   se.fit = as.data.frame(preds$se.fit)
   preds = cbind(fit,se.fit)
   names(preds) = c(paste('fit',names(fit),sep='.'),paste('se.fit',names(fit),sep='.'))
-  .$preds = cbind(.$data,preds)
+  .$preds = bind_cols(.$data,preds)
   #Calculate influences and statisitcs
   .$influences = data.frame(level=levels(.$model$model[,.$focus]))
   overall = c(NA,NA) # NAs for null model and for focus term


### PR DESCRIPTION
An update to tidyr, ggplot2 or PBS Mapping is leading to influ predictions sometimes not getting correctly bound to influ$data. Unfortunately, this leads to a warning and influ$preds being the wrong dimensions.
this follows through to the following error message when trying to aggregate predictors because influ$preds has the wrong column names:
 Error in .$preds[, paste("fit", term, sep = ".")] :
 subscript out of bounds
Calls: <Anonymous> -> res -> aggregate
In addition: Warning message:
In cbind(.$data, preds) :
number of rows of result is not a multiple of vector length (arg 2)
Execution halted