### PR TITLE
make influ$preds more robust

### DIFF
--- a/influ.R
+++ b/influ.R
@@ -262,7 +262,7 @@ Influence$calc <- function(.){
   preds = predict(.$model,type='terms',se.fit=T)
   fit = as.data.frame(preds$fit)
   se.fit = as.data.frame(preds$se.fit)
-  preds = cbind(fit,se.fit)
+  preds = as.data.frame(bind_cols(fit,se.fit))
   names(preds) = c(paste('fit',names(fit),sep='.'),paste('se.fit',names(fit),sep='.'))
   .$preds = cbind(.$data,preds)
   #Calculate influences and statisitcs


### PR DESCRIPTION
An update to tidyr, ggplot2 or PBS Mapping is leading to influ$preds sometimes not getting correctly bound to influ$data. Unfortunately, this leads to a warning and influ$preds being the wrong dimensions.
this follows through to the following error message when trying to aggregate predictors because influ$preds has the wrong column names:
Error in .$preds[, paste("fit", term, sep = ".")] :
subscript out of bounds
Calls: -> res -> aggregate
In addition: Warning message:
In cbind(.$data, preds) :
number of rows of result is not a multiple of vector length (arg 2)
Execution halted